### PR TITLE
fixed setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,41 @@ First, clone the repository - this creates a new directory `./scikit_mobility`.
           env=$(basename `echo $CONDA_PREFIX`)
           python -m ipykernel install --user --name "$env" --display-name "Python [conda env:"$env"]"
           
+### without conda (python >= 3.6 required)
+
+
+1. Create an environment `skmob`
+
+        python3 -m venv skmob
+
+2. Activate
+    
+        source skmob/bin/activate
+
+3. Install skmob
+
+        cd scikit_mobility
+        python setup.py install
+
+
+4. OPTIONAL to use `scikit-mobility` on the jupyter notebook
+
+	- Activate the virutalenv:
+	
+			source skmob/bin/activate
+	
+	- Install jupyter notebook:
+		
+			pip install jupyter 
+	
+	- Run jupyter notebook 			
+			
+			jupyter notebook
+			
+	- (Optional) install the kernel with a specific name
+			
+			ipython kernel install --user --name=skmob
+			
           
 ### Test the installation
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
 setup(
     name='scikit-mobility',
     version='0.0.1dev',
-    packages=['skmob'],
+    packages=['skmob', 'skmob.core', 'skmob.utils', 'skmob.io', 'skmob.measures', 'skmob.models', 'skmob.preprocessing', 'skmob.privacy', 'skmob.tessellation' ],
     license='MIT',
     python_requires='>=3.6',
     description='A toolbox for analyzing and processing mobility data.',


### PR DESCRIPTION
I havent tested with conda, but with python Python 3.7.3 and plain virtualenv the previous setup.py did not work (core, io, modules etc where not included and only an empty egg package was generated.) 

I believe that it worked till now only because the folder from which the interpreter was lunched was the root directory of the sckit-mobility package (i.e. as it is it would not work if you call it from another directory). 

This patch should fix the problem.