### PR TITLE
Fixed installation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ First, clone the repository - this creates a new directory `./scikit_mobility`.
 
 1. Create an environment `skmob` and install pip
 
-        conda create -n skmob pip
+        conda create -n skmob pip python=3.7
 
 2. Activate
     
-        conda activate skmob
+        source activate skmob
 
 3. Install skmob
 
@@ -74,6 +74,12 @@ First, clone the repository - this creates a new directory `./scikit_mobility`.
     
           env=$(basename `echo $CONDA_PREFIX`)
           python -m ipykernel install --user --name "$env" --display-name "Python [conda env:"$env"]"
+
+:exclamation: You may run into dependency issues if you try to import the package in Python. If so, try installing the following packages as followed.
+
+```
+conda install -n skmob pyproj urllib3 chardet markupsafe
+```
           
 ### without conda (python >= 3.6 required)
 


### PR DESCRIPTION
Hi there,

My classmates and I are using this package for a class project. However, we were all running into installation issues, which I think that I have solved. If someone can check my solution, that would be great:

- When executing "conda create -n skmob pip", it seems that Python3.8 is automatically chosen. Then, there seems to be issues with GDAL (?) and I think that using Python3.7 would circumvent this.
- If using Python3.7, upon installing skmob, there seems to be a few other packages that need to be installed: pyproj, urllib3, chardet and markupsafe

I am not sure what the cause of these issues are though...

Thanks!

Larry