### PR TITLE
Fix and optimize real entropy calculation

### DIFF
--- a/skmob/measures/individual.py
+++ b/skmob/measures/individual.py
@@ -357,28 +357,28 @@ def uncorrelated_entropy(traj, normalize=False, show_progress=True):
     return pd.DataFrame(df).reset_index().rename(columns={0: column_name})
 
 
-def _stringify(seq):
-    return '|'.join(['_'.join(list(map(str, r))) for r in seq])
-
-
 def _true_entropy(sequence):
     n = len(sequence)
 
     # these are the first and last elements
     sum_lambda = 1. + 2.
 
+    def in_seq(a, b):
+        for i in range(len(a) - len(b) + 1):
+            valid = True
+            for j, v in enumerate(b):
+                if a[i + j] != v:
+                    valid = False
+                    break
+            if valid: return True
+        return False
+
     for i in range(1, n - 1):
-        str_seq = _stringify(sequence[:i])
-        j = 1
-        str_sub_seq = _stringify(sequence[i:i + j])
-        while str_sub_seq in str_seq:
+        j = i + 1
+        while j < n and in_seq(sequence[:i], sequence[i:j]):
             j += 1
-            str_sub_seq = _stringify(sequence[i:i + j])
-            if i + j == n:
-                # EOF character
-                j += 1
-                break
-        sum_lambda += j
+        if j == n: j += 1     # EOF character
+        sum_lambda += j - i
 
     return 1. / sum_lambda * n * np.log2(n)
 


### PR DESCRIPTION
The function calculating real entropy, **_true_entropy()**, uses a substring search to look for occurrences of contiguous segments in a list. However, it considers [(2, 3), (4, 5), …] to be a subsegment of [(12, 3), (4, 5)…], as "2_3|4_5|…" is a substring of "12_3|4_5|…", leading to incorrect outcomes. A demonstration:

```py
a = [(78, 9), (8, 9), (0, 0)]
tdf = skmob.TrajDataFrame(a, latitude=0, longitude=1)
print(real_entropy(tdf).real_entropy[0])
# prints 0.79248
# but actual entropy should be 1/(3+1) * 3 * log2(3) = 1.18872
```

Adding a "|" character around the sequence stringification solves the problem ("|2_3|4_5|…|" does not match "|12_3|4_5|…|"), but direct element-to-element comparison is equally concise and actually many times faster (4-6x according to local benchmarks, for trajectories of up to 5000 records). This patch implements the latter approach.

I can add some tests and benchmarks if needed. Even further optimization is possible (probably at the cost of a bit increased complexity), and if it's desirable I will be happy to contribute.

Thanks for taking time to look into this.