### PR TITLE
docs: fix syntax error in docstrings

### DIFF
--- a/skmob/core/flowdataframe.py
+++ b/skmob/core/flowdataframe.py
@@ -56,7 +56,7 @@ class FlowDataFrame(pd.DataFrame):
     >>> import skmob
     >>> import geopandas as gpd
     >>> # load a spatial tessellation
-    >>> url_tess = >>> url = skmob.utils.constants.NY_COUNTIES_2011
+    >>> url_tess = skmob.utils.constants.NY_COUNTIES_2011
     >>> tessellation = gpd.read_file(url_tess).rename(columns={'tile_id': 'tile_ID'})
     >>> print(tessellation.head())
       tile_ID  population                                           geometry
@@ -183,7 +183,7 @@ class FlowDataFrame(pd.DataFrame):
         >>> import skmob
         >>> import geopandas as gpd
         >>> # load a spatial tessellation
-        >>> url_tess = >>> url = skmob.utils.constants.NY_COUNTIES_2011
+        >>> url_tess = skmob.utils.constants.NY_COUNTIES_2011
         >>> tessellation = gpd.read_file(url_tess).rename(columns={'tile_id': 'tile_ID'})
         >>> print(tessellation.head())
           tile_ID  population                                           geometry
@@ -534,7 +534,7 @@ class FlowDataFrame(pd.DataFrame):
         >>> import skmob
         >>> import geopandas as gpd
         >>> # load a spatial tessellation
-        >>> url_tess = >>> url = skmob.utils.constants.NY_COUNTIES_2011
+        >>> url_tess = skmob.utils.constants.NY_COUNTIES_2011
         >>> tessellation = gpd.read_file(url_tess).rename(columns={'tile_id': 'tile_ID'})    
         >>> # load real flows into a FlowDataFrame
         >>> # download the file with the real fluxes from: https://raw.githubusercontent.com/scikit-mobility/scikit-mobility/master/tutorial/data/NY_commuting_flows_2011.csv
@@ -602,7 +602,7 @@ class FlowDataFrame(pd.DataFrame):
         >>> import skmob
         >>> import geopandas as gpd
         >>> # load a spatial tessellation
-        >>> url_tess = >>> url = skmob.utils.constants.NY_COUNTIES_2011
+        >>> url_tess = skmob.utils.constants.NY_COUNTIES_2011
         >>> tessellation = gpd.read_file(url_tess).rename(columns={'tile_id': 'tile_ID'})    
         >>> # load real flows into a FlowDataFrame
         >>> # download the file with the real fluxes from: https://raw.githubusercontent.com/scikit-mobility/scikit-mobility/master/tutorial/data/NY_commuting_flows_2011.csv

--- a/skmob/models/gravity.py
+++ b/skmob/models/gravity.py
@@ -154,7 +154,7 @@ class Gravity:
     >>> import numpy as np
     >>> from skmob.models import Gravity
     >>> # load a spatial tessellation
-    >>> url_tess = >>> url = skmob.utils.constants.NY_COUNTIES_2011
+    >>> url_tess = skmob.utils.constants.NY_COUNTIES_2011
     >>> tessellation = gpd.read_file(url_tess).rename(columns={'tile_id': 'tile_ID'})
     >>> print(tessellation.head())
       tile_ID  population                                           geometry

--- a/skmob/models/radiation.py
+++ b/skmob/models/radiation.py
@@ -40,7 +40,7 @@ class Radiation:
     >>> import numpy as np
     >>> from skmob.models import Radiation
     >>> # load a spatial tessellation
-    >>> url_tess = >>> url = skmob.utils.constants.NY_COUNTIES_2011
+    >>> url_tess = skmob.utils.constants.NY_COUNTIES_2011
     >>> tessellation = gpd.read_file(url_tess).rename(columns={'tile_id': 'tile_ID'})
     >>> print(tessellation.head())
       tile_ID  population                                           geometry


### PR DESCRIPTION
Fix error in the examples of the following docstrings: 

* `flowdataframe.py`
    * class `FlowDataFrame`
        * `get_flow`
        * `plot_flows`
        * `plot_tessellation`
* `radiation.py`
    * class `Radiation`
* `gravity.py`
    * class `Gravity` 

Close #145