### PR TITLE
Fixes #152

### DIFF
--- a/skmob/utils/constants.py
+++ b/skmob/utils/constants.py
@@ -2,8 +2,8 @@
 Useful constants
 """
 
-UNIVERSAL_CRS = {"init": "epsg:3857"}
-DEFAULT_CRS = {"init": "epsg:4326"}
+UNIVERSAL_CRS = {"epsg": "3857"}
+DEFAULT_CRS = {"epsg": "4326"}
 
 UID = 'uid'
 TID = 'tid'


### PR DESCRIPTION
Replaces  PYPROJ deprecated syntax `+init=<authority>:<code>` with `<auth>:<auth_code>` as detailed [here](https://pyproj4.github.io/pyproj/stable/gotchas.html)