### PR TITLE
rename stops to stay_locations in preprocessing.detection

### DIFF
--- a/docs/reference/preprocessing.rst
+++ b/docs/reference/preprocessing.rst
@@ -7,12 +7,10 @@ Preprocessing
 	
 	filtering.filter
 	compression.compress
-	detection.stops
+	detection.stay_locations
 	clustering.cluster
-	routing.route
 
 .. autofunction:: skmob.preprocessing.filtering.filter
 .. autofunction:: skmob.preprocessing.compression.compress
-.. autofunction:: skmob.preprocessing.detection.stops
+.. autofunction:: skmob.preprocessing.detection.stay_locations
 .. autofunction:: skmob.preprocessing.clustering.cluster
-.. autofunction:: skmob.preprocessing.routing.route

--- a/skmob/core/tests/test_trajectorydataframe.py
+++ b/skmob/core/tests/test_trajectorydataframe.py
@@ -44,7 +44,7 @@ class TestTrajectoryDataFrame:
             '20130101 4:34:55', '20130105 5:29:12', '20130115 00:29:12'])
         traj[constants.UID] = [1 for _ in range(5)] + [2 for _ in range(3)] + [3]
         self.tdf0 = TrajDataFrame(traj)
-        self.stdf = detection.stops(self.tdf0)
+        self.stdf = detection.stay_locations(self.tdf0)
         self.cstdf = clustering.cluster(self.stdf)
 
         # tessellation

--- a/skmob/core/trajectorydataframe.py
+++ b/skmob/core/trajectorydataframe.py
@@ -575,7 +575,7 @@ class TrajDataFrame(pd.DataFrame):
                hex_color=None, opacity=0.3, radius=12, number_of_sides=4, popup=True, control_scale=True):
 
         """
-        Plot the stops in the TrajDataFrame on a Folium map. This function requires a TrajDataFrame with stops or clusters, output of `preprocessing.detection.stops` or `preprocessing.clustering.cluster` functions. The column `constants.LEAVING_DATETIME` must be present.
+        Plot the stops in the TrajDataFrame on a Folium map. This function requires a TrajDataFrame with stops or clusters, output of `preprocessing.detection.stay_locations` or `preprocessing.clustering.cluster` functions. The column `constants.LEAVING_DATETIME` must be present.
         
         Parameters
         ----------
@@ -630,7 +630,7 @@ class TrajDataFrame(pd.DataFrame):
         2  39.984224  116.319402 2008-10-23 05:53:11    1
         3  39.984211  116.319389 2008-10-23 05:53:16    1
         4  39.984217  116.319422 2008-10-23 05:53:21    1
-        >>> stdf = detection.stops(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_km=0.2, leaving_time=True)
+        >>> stdf = detection.stay_locations(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_km=0.2, leaving_time=True)
         >>> print(stdf.head())
                  lat         lng            datetime  uid    leaving_datetime
         0  39.978030  116.327481 2008-10-23 06:01:37    1 2008-10-23 10:32:53
@@ -691,7 +691,7 @@ class TrajDataFrame(pd.DataFrame):
         3  39.984211  116.319389 2008-10-23 05:53:16    1
         4  39.984217  116.319422 2008-10-23 05:53:21    1
         >>> # detect stops
-        >>> stdf = detection.stops(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_km=0.2, leaving_time=True)
+        >>> stdf = detection.stay_locations(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_km=0.2, leaving_time=True)
         >>> print(stdf.head())
                  lat         lng            datetime  uid    leaving_datetime
         0  39.978030  116.327481 2008-10-23 06:01:37    1 2008-10-23 10:32:53

--- a/skmob/models/epr.py
+++ b/skmob/models/epr.py
@@ -748,7 +748,7 @@ class Ditras(EPR):
     >>> df = pd.read_csv(url, sep=',', compression='gzip')
     >>> tdf = skmob.TrajDataFrame(df, latitude='lat', longitude='lon', user_id='user', datetime='datetime')
     >>> ctdf = compression.compress(tdf)
-    >>> stdf = detection.stops(ctdf)
+    >>> stdf = detection.stay_locations(ctdf)
     >>> cstdf = clustering.cluster(stdf)
     >>> 
     >>> # instantiate and train the MarkovDiaryGenerator

--- a/skmob/models/tests/test_epr.py
+++ b/skmob/models/tests/test_epr.py
@@ -80,7 +80,7 @@ def global_variables():
         '20130101 4:34:55', '20130105 5:29:12', '20130115 00:29:12'])
     traj[constants.UID] = [1 for _ in range(5)] + [2 for _ in range(3)] + [3]
     tdf = TrajDataFrame(traj)
-    stdf = detection.stops(tdf)
+    stdf = detection.stay_locations(tdf)
     cstdf = clustering.cluster(stdf)
     return tessellation, gm, gmfdf, gcgm, odM, cstdf
 

--- a/skmob/preprocessing/clustering.py
+++ b/skmob/preprocessing/clustering.py
@@ -57,7 +57,7 @@ def cluster(tdf, cluster_radius_km=0.1, min_samples=1):
     3  39.981166  116.308475 2008-10-24 02:02:31    1 2008-10-24 02:30:29       42
     4  39.981431  116.309902 2008-10-24 02:30:29    1 2008-10-24 03:16:35       41    
     >>> print(cstdf.parameters)
-    {'detect': {'function': 'stops', 'stop_radius_factor': 0.5, 'minutes_for_a_stop': 20.0, 'spatial_radius_km': 0.2, 'leaving_time': True, 'no_data_for_minutes': 1000000000000.0, 'min_speed_kmh': None}, 'cluster': {'function': 'cluster', 'cluster_radius_km': 0.1, 'min_samples': 1}}
+    {'detect': {'function': 'stay_locations', 'stop_radius_factor': 0.5, 'minutes_for_a_stop': 20.0, 'spatial_radius_km': 0.2, 'leaving_time': True, 'no_data_for_minutes': 1000000000000.0, 'min_speed_kmh': None}, 'cluster': {'function': 'cluster', 'cluster_radius_km': 0.1, 'min_samples': 1}}
 
     References
     ----------
@@ -80,7 +80,7 @@ def cluster(tdf, cluster_radius_km=0.1, min_samples=1):
     #     groupby.append(constants.TID)
 
     stops_df = tdf
-    # stops_df = detection.stops(data, stop_radius_factor=0.5, \
+    # stops_df = detection.stay_locations(data, stop_radius_factor=0.5, \
     #         minutes_for_a_stop=20.0, spatial_radius=0.2, leaving_time=True)
 
     if len(groupby) > 0:

--- a/skmob/preprocessing/detection.py
+++ b/skmob/preprocessing/detection.py
@@ -4,7 +4,7 @@ import numpy as np
 import inspect
 
 
-def stops(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_km=0.2, leaving_time=True, no_data_for_minutes=1e12, min_speed_kmh=None):
+def stay_locations(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_km=0.2, leaving_time=True, no_data_for_minutes=1e12, min_speed_kmh=None):
     """Stops detection.
     
     Detect the stops for each individual in a TrajDataFrame. A stop is detected when the individual spends at least `minutes_for_a_stop` minutes within a distance `stop_radius_factor * spatial_radius` km from a given trajectory point. The stop's coordinates are the median latitude and longitude values of the points found within the specified distance [RT2004]_ [Z2015]_.
@@ -80,7 +80,7 @@ def stops(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_k
     # Save function arguments and values in a dictionary
     frame = inspect.currentframe()
     args, _, _, arg_values = inspect.getargvalues(frame)
-    arguments = dict([('function', stops.__name__)]+[(i, arg_values[i]) for i in args[1:]])
+    arguments = dict([('function', stay_locations.__name__)]+[(i, arg_values[i]) for i in args[1:]])
 
     groupby = []
 
@@ -99,11 +99,11 @@ def stops(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_k
 
     if len(groupby) > 0:
         # Apply simplify trajectory to each group of points
-        stdf = tdf.groupby(groupby, group_keys=False, as_index=False).apply(_stops_trajectory, stop_radius=stop_radius,
+        stdf = tdf.groupby(groupby, group_keys=False, as_index=False).apply(_stay_locations_trajectory, stop_radius=stop_radius,
                            minutes_for_a_stop=minutes_for_a_stop, leaving_time=leaving_time,
                            no_data_for_minutes=no_data_for_minutes, min_speed_kmh=min_speed_kmh).reset_index(drop=True)
     else:
-        stdf = _stops_trajectory(tdf, stop_radius=stop_radius, minutes_for_a_stop=minutes_for_a_stop,
+        stdf = _stay_locations_trajectory(tdf, stop_radius=stop_radius, minutes_for_a_stop=minutes_for_a_stop,
                             leaving_time=leaving_time, no_data_for_minutes=no_data_for_minutes,
                             min_speed_kmh=min_speed_kmh).reset_index(drop=True)
 
@@ -115,29 +115,29 @@ def stops(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_k
     return stdf
 
 
-def _stops_trajectory(tdf, stop_radius, minutes_for_a_stop, leaving_time, no_data_for_minutes, min_speed_kmh):
+def _stay_locations_trajectory(tdf, stop_radius, minutes_for_a_stop, leaving_time, no_data_for_minutes, min_speed_kmh):
 
     # From dataframe convert to numpy matrix
     lat_lng_dtime_other = list(utils.to_matrix(tdf))
     columns_order = list(tdf.columns)
 
-    stops, leaving_times = _stops_array(lat_lng_dtime_other, stop_radius,
+    stay_locations, leaving_times = _stay_locations_array(lat_lng_dtime_other, stop_radius,
                                         minutes_for_a_stop, leaving_time, no_data_for_minutes, min_speed_kmh)
 
     #print(utils.get_columns(data))
-    # stops = utils.to_dataframe(stops, utils.get_columns(data))
-    stops = nparray_to_trajdataframe(stops, utils.get_columns(tdf), {})
+    # stay_locations = utils.to_dataframe(stay_locations, utils.get_columns(data))
+    stay_locations = nparray_to_trajdataframe(stay_locations, utils.get_columns(tdf), {})
 
     # Put back to the original order
-    stops = stops[columns_order]
+    stay_locations = stay_locations[columns_order]
 
     if leaving_time:
-        stops.loc[:, constants.LEAVING_DATETIME] = pd.to_datetime(leaving_times)
+        stay_locations.loc[:, constants.LEAVING_DATETIME] = pd.to_datetime(leaving_times)
 
-    return stops
+    return stay_locations
 
 
-def _stops_array(lat_lng_dtime_other, stop_radius, minutes_for_a_stop, leaving_time, no_data_for_minutes, min_speed_kmh):
+def _stay_locations_array(lat_lng_dtime_other, stop_radius, minutes_for_a_stop, leaving_time, no_data_for_minutes, min_speed_kmh):
     """
     Create a stop if the user spend at least `minutes_for_a_stop` minutes
     within a distance `stop_radius` from a given point.
@@ -145,7 +145,7 @@ def _stops_array(lat_lng_dtime_other, stop_radius, minutes_for_a_stop, leaving_t
     # Define the distance function to use
     measure_distance = gislib.getDistance
 
-    stops = []
+    stay_locations = []
     leaving_times = []
 
     lat_0, lon_0, t_0 = lat_lng_dtime_other[0][:3]
@@ -196,7 +196,7 @@ def _stops_array(lat_lng_dtime_other, stop_radius, minutes_for_a_stop, leaving_t
                     if leaving_time:
                         leaving_times.append(estimated_final_t)
 
-                    stops += [[np.median(sum_lat), np.median(sum_lon), t_0] + extra_cols]
+                    stay_locations += [[np.median(sum_lat), np.median(sum_lon), t_0] + extra_cols]
 
                 count = 0
                 lat_0, lon_0, t_0 = lat, lon, t
@@ -214,4 +214,4 @@ def _stops_array(lat_lng_dtime_other, stop_radius, minutes_for_a_stop, leaving_t
         sum_lon += [lon]
         sum_t += [t]
 
-    return stops, leaving_times
+    return stay_locations, leaving_times

--- a/skmob/preprocessing/detection.py
+++ b/skmob/preprocessing/detection.py
@@ -7,7 +7,7 @@ import inspect
 def stay_locations(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_km=0.2, leaving_time=True, no_data_for_minutes=1e12, min_speed_kmh=None):
     """Stops detection.
     
-    Detect the stops for each individual in a TrajDataFrame. A stop is detected when the individual spends at least `minutes_for_a_stop` minutes within a distance `stop_radius_factor * spatial_radius` km from a given trajectory point. The stop's coordinates are the median latitude and longitude values of the points found within the specified distance [RT2004]_ [Z2015]_.
+    Detect the stay locations (or stops) for each individual in a TrajDataFrame. A stop is detected when the individual spends at least `minutes_for_a_stop` minutes within a distance `stop_radius_factor * spatial_radius` km from a given trajectory point. The stop's coordinates are the median latitude and longitude values of the points found within the specified distance [RT2004]_ [Z2015]_.
     
     Parameters
     ----------
@@ -54,7 +54,7 @@ def stay_locations(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial
     2  39.984224  116.319402 2008-10-23 05:53:11    1
     3  39.984211  116.319389 2008-10-23 05:53:16    1
     4  39.984217  116.319422 2008-10-23 05:53:21    1
-    >>> stdf = detection.stops(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_km=0.2, leaving_time=True)
+    >>> stdf = detection.stay_locations(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial_radius_km=0.2, leaving_time=True)
     >>> print(stdf.head())
              lat         lng            datetime  uid    leaving_datetime
     0  39.978030  116.327481 2008-10-23 06:01:37    1 2008-10-23 10:32:53
@@ -63,7 +63,7 @@ def stay_locations(tdf, stop_radius_factor=0.5, minutes_for_a_stop=20.0, spatial
     3  39.981166  116.308475 2008-10-24 02:02:31    1 2008-10-24 02:30:29
     4  39.981431  116.309902 2008-10-24 02:30:29    1 2008-10-24 03:16:35
     >>> print(stdf.parameters)
-    {'detect': {'function': 'stops', 'stop_radius_factor': 0.5, 'minutes_for_a_stop': 20.0, 'spatial_radius_km': 0.2, 'leaving_time': True, 'no_data_for_minutes': 1000000000000.0, 'min_speed_kmh': None}}
+    {'detect': {'function': 'stay_locations', 'stop_radius_factor': 0.5, 'minutes_for_a_stop': 20.0, 'spatial_radius_km': 0.2, 'leaving_time': True, 'no_data_for_minutes': 1000000000000.0, 'min_speed_kmh': None}}
     >>> print('Points of the original trajectory:\\t%s'%len(tdf))
     >>> print('Points of stops:\\t\\t\\t%s'%len(stdf))
     Points of the original trajectory:	217653

--- a/skmob/preprocessing/tests/test_detection.py
+++ b/skmob/preprocessing/tests/test_detection.py
@@ -92,7 +92,7 @@ class TestDetection:
         self.trjdat = TrajDataFrame(traj, user_id=user_id)
 
     def test_stops(self):
-        output = detection.stops(self.trjdat)
+        output = detection.stay_locations(self.trjdat)
 
         expected = self.trjdat.drop([3, 7, 11, 14, 17, 19, 21, 22])
         stamps = [
@@ -124,7 +124,7 @@ class TestDetection:
         # assert
         pd.testing.assert_frame_equal(output, expected, check_dtype=False)
 
-        output = detection.stops(self.trjdat, minutes_for_a_stop=60.0, leaving_time=False)
+        output = detection.stay_locations(self.trjdat, minutes_for_a_stop=60.0, leaving_time=False)
 
         expected = self.trjdat.drop([0, 1, 3, 4, 6, 7, 8, 10, 11, 12, 13, 14, 15, 17, 18, 19, 21, 22])
 

--- a/skmob/preprocessing/tests/test_detection.py
+++ b/skmob/preprocessing/tests/test_detection.py
@@ -91,7 +91,7 @@ class TestDetection:
         self.traj = traj.sort_values([user_id, date_time])
         self.trjdat = TrajDataFrame(traj, user_id=user_id)
 
-    def test_stops(self):
+    def test_stay_locations(self):
         output = detection.stay_locations(self.trjdat)
 
         expected = self.trjdat.drop([3, 7, 11, 14, 17, 19, 21, 22])

--- a/skmob/utils/tests/test_plots.py
+++ b/skmob/utils/tests/test_plots.py
@@ -124,7 +124,7 @@ def test_plot_stops(tdf):
     map_f = plot.plot_trajectory(tdf)
     # map_f = plot.plot_stops(tdf, map_f=map_f)
 
-    stdf = detection.stops(tdf)
+    stdf = detection.stay_locations(tdf)
     map_f = plot.plot_stops(stdf, map_f=map_f)
 
     assert isinstance(map_f, folium.folium.Map)
@@ -135,7 +135,7 @@ def test_plot_stops_tdf(tdf):
     map_f = tdf.plot_trajectory()
     # map_f = tdf.plot_stops(map_f=map_f)
 
-    stdf = detection.stops(tdf)
+    stdf = detection.stay_locations(tdf)
     map_f = stdf.plot_stops(map_f=map_f)
 
     assert isinstance(map_f, folium.folium.Map)
@@ -147,7 +147,7 @@ def test_plot_stops_tdf(tdf):
 @pytest.mark.parametrize('user', [1, 2])
 @pytest.mark.parametrize('start_datetime', [None, '2013/01/01 00:00:00'])
 def test_plot_diary(tdf, user, start_datetime):
-    stdf = detection.stops(tdf)
+    stdf = detection.stay_locations(tdf)
     cstdf = clustering.cluster(stdf)
     ax = plot.plot_diary(cstdf, user, start_datetime=start_datetime)
 
@@ -158,7 +158,7 @@ def test_plot_diary(tdf, user, start_datetime):
 @pytest.mark.parametrize('user', [1, 2])
 @pytest.mark.parametrize('start_datetime', [None, '2013/01/01 00:00:00'])
 def test_plot_diary(tdf, user, start_datetime):
-    stdf = detection.stops(tdf)
+    stdf = detection.stay_locations(tdf)
     cstdf = clustering.cluster(stdf)
     ax = cstdf.plot_diary(user, start_datetime=start_datetime)
 


### PR DESCRIPTION
In response to issue #14: renamed stops to stay locations in the preprocessing.detection to be more in line with the literature/language used in Toyama 2004. 