### PR TITLE
Suppres divide by zero warnning in gravity models

### DIFF
--- a/skmob/models/gravity.py
+++ b/skmob/models/gravity.py
@@ -40,7 +40,8 @@ def powerlaw_deterrence_func(x, exponent):
     """
     Power law deterrence function
     """
-    return np.power(x, exponent)
+    with np.errstate(divide='ignore'):
+        return np.power(x, exponent)
 
 
 def compute_distance_matrix(spatial_tessellation, origins):


### PR DESCRIPTION
At file `skmob/models/epr.py` line 78-81
```python
    ll_origin = lats_lngs[location]
    distances = np.array([earth_distance_km(ll_origin, l) for l in lats_lngs])
```
This calculation results in a 0 in the distances.
When using the d-epr model to generate, this causes a divide by zero warning.
<img width="1155" alt="image" src="https://github.com/scikit-mobility/scikit-mobility/assets/59809602/be50410f-cd6a-4321-b0d2-8ada8151334a">
As shown in the screenshot of IDEA, on the right is the stack tracking when the error occurs.
<img width="1155" alt="image" src="https://github.com/scikit-mobility/scikit-mobility/assets/59809602/8d577406-a1e9-4de0-847a-f3d4827144df">
Therefore, I think in order to ensure the user experience, zero can be suppressed here.
I don't know if this is a good code habit. If you want, you can refactor the whole code to ensure that the inevitable zero will not be generated when calculating the position distance.